### PR TITLE
[AS7-2639] add to ServiceName.getSimpleName() to the exception message t...

### DIFF
--- a/src/main/java/org/jboss/msc/service/ServiceName.java
+++ b/src/main/java/org/jboss/msc/service/ServiceName.java
@@ -74,15 +74,15 @@ public final class ServiceName implements Comparable<ServiceName>, Serializable 
      */
     public static ServiceName of(final ServiceName parent, String... parts) {
         if(parts.length < 1)
-            throw new IllegalArgumentException("Must provide at least one name segment");
+            throw new IllegalArgumentException("Must provide at least one name segment for " + parent.getSimpleName());
         
         ServiceName current = parent;
         for (String part : parts) {
             if (part == null) {
-                throw new IllegalArgumentException("Name segment is null");
+                throw new IllegalArgumentException("Name segment is null for " + current.getSimpleName());
             }
             if (part.isEmpty()) {
-                throw new IllegalArgumentException("Empty name segment is not allowed");
+                throw new IllegalArgumentException("Empty name segment is not allowed for " + current.getSimpleName());
             }
             current = new ServiceName(current, part);
         }


### PR DESCRIPTION
I've improved the MSC message when there are issues parsing deployment descriptors, so that the exception will include the element name in the exception so that the user knows where to lock for the problem.

Example if you have a <security-domain/> empty in a war/WEB-INF/jboss-web.xml then you get the error message below.

Before the fix:
Caused by: java.lang.IllegalArgumentException: Empty name segment is not allowed

After the fix:
Caused by: java.lang.IllegalArgumentException: Empty name segment is not allowed for security-domain
