### PR TITLE
[MSC-131] always remove controller from all stability monitors if contro...

### DIFF
--- a/src/main/java/org/jboss/msc/service/DelegatingServiceContainer.java
+++ b/src/main/java/org/jboss/msc/service/DelegatingServiceContainer.java
@@ -174,6 +174,11 @@ public final class DelegatingServiceContainer implements ServiceContainer {
     }
 
     /** {@inheritDoc} */
+    public boolean isShutdown() {
+        throw new UnsupportedOperationException();
+    }
+
+    /** {@inheritDoc} */
     public boolean isShutdownComplete() {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/org/jboss/msc/service/ServiceContainer.java
+++ b/src/main/java/org/jboss/msc/service/ServiceContainer.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
  * A service container which manages a set of running services.
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
 public interface ServiceContainer extends ServiceTarget, ServiceRegistry {
 
@@ -37,6 +38,13 @@ public interface ServiceContainer extends ServiceTarget, ServiceRegistry {
      * Stop all services within this container.
      */
     void shutdown();
+    
+    /**
+     * Whether container have been shut down.
+     *
+     * @return {@code true} if container is shutting down 
+     */
+    boolean isShutdown();
 
     /**
      * Determine whether the container is completely shut down.

--- a/src/main/java/org/jboss/msc/service/ServiceContainerImpl.java
+++ b/src/main/java/org/jboss/msc/service/ServiceContainerImpl.java
@@ -499,7 +499,7 @@ final class ServiceContainerImpl extends ServiceTargetImpl implements ServiceCon
         return this;
     }
 
-    boolean isShutdown() {
+    public boolean isShutdown() {
         return down;
     }
 

--- a/src/main/java/org/jboss/msc/service/ServiceControllerImpl.java
+++ b/src/main/java/org/jboss/msc/service/ServiceControllerImpl.java
@@ -683,6 +683,9 @@ final class ServiceControllerImpl<S> implements ServiceController<S>, Dependent 
                 case REMOVING_to_REMOVED: {
                     getListenerTasks(transition, tasks);
                     listeners.clear();
+                    for (final StabilityMonitor monitor : monitors) {
+                        monitor.removeControllerNoCallback(this);
+                    }
                     break;
                 }
                 case REMOVING_to_DOWN: {
@@ -1485,7 +1488,6 @@ final class ServiceControllerImpl<S> implements ServiceController<S>, Dependent 
     void addMonitor(final StabilityMonitor stabilityMonitor) {
         assert !holdsLock(this);
         synchronized (this) {
-            final Substate state = this.state;
             if (monitors.add(stabilityMonitor) && !isStableRestState()) {
                 stabilityMonitor.incrementUnstableServices();
                 if (state == Substate.START_FAILED) {

--- a/src/main/java/org/jboss/msc/service/StabilityStatistics.java
+++ b/src/main/java/org/jboss/msc/service/StabilityStatistics.java
@@ -138,6 +138,7 @@ public final class StabilityStatistics {
      * {@link ServiceController.Mode#REMOVE} mode.
      * @return count of <b>REMOVE</b> controllers
      */
+    @Deprecated
     public int getRemovedCount() {
         return removed;
     }


### PR DESCRIPTION
...ller is transitioning from REMOVING to REMOVED
- deprecated StabilityStatistics.getRemovedCount() because this statistics becomes invalid when this fix is applied
  - exposed ServiceContainer.isShutdown() method to be used instead of StabilityStatistics.getRemovedCount() in AS BootstrapListener
    in order to be able to detect ServiceContainer is going down.
