### PR TITLE
[MSC-131] always remove controller from all stability monitors if contro...

### DIFF
--- a/src/main/java/org/jboss/msc/service/DelegatingServiceContainer.java
+++ b/src/main/java/org/jboss/msc/service/DelegatingServiceContainer.java
@@ -157,6 +157,11 @@ public final class DelegatingServiceContainer implements ServiceContainer {
     }
 
     /** {@inheritDoc} */
+    public boolean isShutdown() {
+        throw new UnsupportedOperationException();
+    }
+
+    /** {@inheritDoc} */
     public boolean isShutdownComplete() {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/org/jboss/msc/service/ServiceContainer.java
+++ b/src/main/java/org/jboss/msc/service/ServiceContainer.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
  * A service container which manages a set of running services.
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
 public interface ServiceContainer extends ServiceTarget, ServiceRegistry {
 
@@ -37,6 +38,13 @@ public interface ServiceContainer extends ServiceTarget, ServiceRegistry {
      * Stop all services within this container.
      */
     void shutdown();
+    
+    /**
+     * Whether container have been shut down.
+     *
+     * @return {@code true} if container is shutting down 
+     */
+    boolean isShutdown();
 
     /**
      * Determine whether the container is completely shut down.

--- a/src/main/java/org/jboss/msc/service/ServiceContainerImpl.java
+++ b/src/main/java/org/jboss/msc/service/ServiceContainerImpl.java
@@ -499,7 +499,7 @@ final class ServiceContainerImpl extends ServiceTargetImpl implements ServiceCon
         return this;
     }
 
-    boolean isShutdown() {
+    public boolean isShutdown() {
         return down;
     }
 

--- a/src/main/java/org/jboss/msc/service/ServiceControllerImpl.java
+++ b/src/main/java/org/jboss/msc/service/ServiceControllerImpl.java
@@ -682,6 +682,9 @@ final class ServiceControllerImpl<S> implements ServiceController<S>, Dependent 
                 case REMOVING_to_REMOVED: {
                     getListenerTasks(transition, tasks);
                     listeners.clear();
+                    for (final StabilityMonitor monitor : monitors) {
+                        monitor.removeControllerNoCallback(this);
+                    }
                     break;
                 }
                 case REMOVING_to_DOWN: {
@@ -1453,7 +1456,6 @@ final class ServiceControllerImpl<S> implements ServiceController<S>, Dependent 
     void addMonitor(final StabilityMonitor stabilityMonitor) {
         assert !holdsLock(this);
         synchronized (this) {
-            final Substate state = this.state;
             if (monitors.add(stabilityMonitor) && !isStableRestState()) {
                 stabilityMonitor.incrementUnstableServices();
                 if (state == Substate.START_FAILED) {

--- a/src/main/java/org/jboss/msc/service/StabilityStatistics.java
+++ b/src/main/java/org/jboss/msc/service/StabilityStatistics.java
@@ -35,7 +35,6 @@ package org.jboss.msc.service;
  *   <li>count of controllers in <b>PASSIVE</b> mode - see method {@link #getPassiveCount()}</li> 
  *   <li>count of controllers that had <b>PROBLEM</b> to start - see method {@link #getProblemsCount()}</li> 
  *   <li>count of controllers in <b>UP</b> state - see method {@link #getStartedCount()}</li> 
- *   <li>count of controllers in <b>REMOVE</b> mode - see method {@link #getRemovedCount()}</li> 
  * </ul>
  * 
  * Sample usage:
@@ -59,7 +58,6 @@ public final class StabilityStatistics {
     private int passive;
     private int problems;
     private int started;
-    private int removed;
 
     /**
      * Returns count of controllers registered with {@link StabilityMonitor} that are in
@@ -133,15 +131,6 @@ public final class StabilityStatistics {
         return started;
     }
     
-    /**
-     * Returns count of controllers registered with {@link StabilityMonitor} that are in
-     * {@link ServiceController.Mode#REMOVE} mode.
-     * @return count of <b>REMOVE</b> controllers
-     */
-    public int getRemovedCount() {
-        return removed;
-    }
-    
     void setActiveCount(final int count) {
         active = count;
     }
@@ -172,9 +161,5 @@ public final class StabilityStatistics {
 
     void setStartedCount(final int count) {
         started = count;
-    }
-
-    void setRemovedCount(final int count) {
-        removed = count;
     }
 }

--- a/src/test/java/org/jboss/msc/service/ContainerStabilityTestCase.java
+++ b/src/test/java/org/jboss/msc/service/ContainerStabilityTestCase.java
@@ -153,7 +153,6 @@ public final class ContainerStabilityTestCase extends AbstractServiceTest {
         assertTrue(statistics.getNeverCount() == 0);
         assertTrue(statistics.getPassiveCount() == 0);
         assertTrue(statistics.getProblemsCount() == 0);
-        assertTrue(statistics.getRemovedCount() == 0);
         stabilityMonitor.clear();
         try {
             stabilityMonitor.awaitStability(statistics);
@@ -168,7 +167,6 @@ public final class ContainerStabilityTestCase extends AbstractServiceTest {
         assertTrue(statistics.getNeverCount() == 0);
         assertTrue(statistics.getPassiveCount() == 0);
         assertTrue(statistics.getProblemsCount() == 0);
-        assertTrue(statistics.getRemovedCount() == 0);
     }
 
     @Test
@@ -223,7 +221,6 @@ public final class ContainerStabilityTestCase extends AbstractServiceTest {
         assertTrue(statistics.getNeverCount() == 0);
         assertTrue(statistics.getPassiveCount() == 0);
         assertTrue(statistics.getProblemsCount() == 0);
-        assertTrue(statistics.getRemovedCount() == 0);
         stabilityMonitor.clear();
         try {
             stabilityMonitor.awaitStability(statistics);
@@ -238,6 +235,5 @@ public final class ContainerStabilityTestCase extends AbstractServiceTest {
         assertTrue(statistics.getNeverCount() == 0);
         assertTrue(statistics.getPassiveCount() == 0);
         assertTrue(statistics.getProblemsCount() == 0);
-        assertTrue(statistics.getRemovedCount() == 0);
     }
 }


### PR DESCRIPTION
...ller is transitioning from REMOVING to REMOVED
- removed StabilityStatistics.getRemovedCount() because this statistics becomes invalid when this fix is applied
  - exposed ServiceContainer.isShutdown() method to be used instead of StabilityStatistics.getRemovedCount() in AS BootstrapListener
    in order to be able to detect ServiceContainer is going down.
