### PR TITLE
Potential fix for not cleaning up canceled services

### DIFF
--- a/src/main/java/org/jboss/msc/service/ServiceController.java
+++ b/src/main/java/org/jboss/msc/service/ServiceController.java
@@ -474,7 +474,11 @@ public interface ServiceController<S> extends Value<S> {
         /**
          * Transition from {@link Substate#WONT_START WONT_START} to {@link Substate#DOWN DOWN}.
          */
-        WONT_START_to_DOWN(Substate.WONT_START, Substate.DOWN);
+        WONT_START_to_DOWN(Substate.WONT_START, Substate.DOWN),
+        /**
+         * Transition from {@link Substate#CANCELLED} to {@link Substate#REMOVED}.
+         */
+        CANCELLED_to_REMOVED(Substate.CANCELLED,Substate.REMOVED);
 
         private final Substate before;
         private final Substate after;

--- a/src/main/java/org/jboss/msc/service/ServiceControllerImpl.java
+++ b/src/main/java/org/jboss/msc/service/ServiceControllerImpl.java
@@ -474,8 +474,11 @@ final class ServiceControllerImpl<S> implements ServiceController<S>, Dependent 
                     return Transition.REMOVING_to_DOWN;
                 }
             }
-            case CANCELLED:
-                // fall thru!
+            case CANCELLED:{
+                if (mode == Mode.REMOVE){
+                    return Transition.CANCELLED_to_REMOVED;
+                }
+            }
             case REMOVED:
             {
                 // no possible actions
@@ -679,6 +682,7 @@ final class ServiceControllerImpl<S> implements ServiceController<S>, Dependent 
                     tasks.add(new RemoveTask());
                     break;
                 }
+                case CANCELLED_to_REMOVED:
                 case REMOVING_to_REMOVED: {
                     getListenerTasks(transition, tasks);
                     listeners.clear();


### PR DESCRIPTION
Controllers don't get removed from StabilityMonitor in case state of service is canceled and not removed. 
For mode = REMOVE

I am not sure this fix is appropriate at all but it does solves leak.

example of memory leak from yourkit

```
+---------------------------------------------------------------------------------------------------------------+-----------------+----------------+
|                                                     Name                                                      |  Retained Size  |  Shallow Size  |
+---------------------------------------------------------------------------------------------------------------+-----------------+----------------+
|  +---org.jboss.as.server.deployment.DeploymentUnitPhaseService                                                |            152  |            32  |
|    |                                                                                                          |                 |                |
|    +---value of org.jboss.msc.value.ImmediateValue                                                            |            168  |            16  |
|      |                                                                                                        |                 |                |
|      +---serviceValue of org.jboss.msc.service.ServiceControllerImpl                                          |          5.432  |           112  |
|        |                                                                                                      |                 |                |
|        +---parent of org.jboss.msc.service.ServiceControllerImpl                                              |          6.256  |           112  |
|          |                                                                                                    |                 |                |
|          +---parent of org.jboss.msc.service.ServiceControllerImpl                                            |        602.744  |           112  |
|            |                                                                                                  |                 |                |
|            +---parent of org.jboss.msc.service.ServiceControllerImpl                                          |            704  |           112  |
|              |                                                                                                |                 |                |
|              +---[275] of java.lang.Object[512]                                                               |        607.904  |         2.064  |
|                |                                                                                              |                 |                |
|                +---table of org.jboss.msc.service.IdentityHashSet                                             |        607.936  |            32  |
|                  |                                                                                            |                 |                |
|                  +---controllers of org.jboss.msc.service.StabilityMonitor                                    |        608.424  |            40  |
|                    |                                                                                          |                 |                |
|                    +---monitor of org.jboss.as.controller.ContainerStateMonitor                               |            496  |            32  |
|                      |                                                                                        |                 |                |
|                      +---stateMonitor of org.jboss.as.controller.ModelControllerImpl                          |          1.256  |            72  |
|                        |                                                                                      |                 |                |
|                        +---controller of org.jboss.as.jmx.model.ModelControllerMBeanHelper                    |            144  |            32  |
|                          |                                                                                    |                 |                |
|                          +---exprHelper of org.jboss.as.jmx.model.ModelControllerMBeanServerPlugin            |            328  |            24  |
|                            |                                                                                  |                 |                |
|                            +---[0] of java.lang.Object[1]                                                     |             16  |            16  |
|                              |                                                                                |                 |                |
|                              +---array of java.util.concurrent.CopyOnWriteArrayList                           |             72  |            16  |
|                                |                                                                              |                 |                |
|                                +---al of java.util.concurrent.CopyOnWriteArraySet                             |             88  |            16  |
|                                  |                                                                            |                 |                |
|                                  +---delegates of org.jboss.as.jmx.PluggableMBeanServerImpl                   |            120  |            16  |
|                                    |                                                                          |                 |                |
|                                    +---platformMBeanServer of java.lang.management.ManagementFactory [Class]  |            448  |           336  |
+---------------------------------------------------------------------------------------------------------------+-----------------+----------------+
```
