### PR TITLE
Make the use of 'jboss.msc.max.container.threads' consistent.

### DIFF
--- a/src/main/java/org/jboss/msc/service/ServiceContainer.java
+++ b/src/main/java/org/jboss/msc/service/ServiceContainer.java
@@ -168,9 +168,7 @@ public interface ServiceContainer extends ServiceTarget, ServiceRegistry {
          * @return a new service container instance
          */
         public static ServiceContainer create() {
-            int cpuCount = Runtime.getRuntime().availableProcessors();
-            int coreSize = Math.min(Math.max(cpuCount << 1, 2), MAX_THREADS_COUNT);
-            return new ServiceContainerImpl(null, coreSize, 30L, TimeUnit.SECONDS, true);
+            return new ServiceContainerImpl(null, calculateCoreSize(), 30L, TimeUnit.SECONDS, true);
         }
 
         /**
@@ -180,9 +178,7 @@ public interface ServiceContainer extends ServiceTarget, ServiceRegistry {
          * @return a new service container instance
          */
         public static ServiceContainer create(String name) {
-            int cpuCount = Runtime.getRuntime().availableProcessors();
-            int coreSize = Math.min(Math.max(cpuCount << 1, 2), MAX_THREADS_COUNT);
-            return new ServiceContainerImpl(name, coreSize, 30L, TimeUnit.SECONDS, true);
+            return new ServiceContainerImpl(name, calculateCoreSize(), 30L, TimeUnit.SECONDS, true);
         }
 
         /**
@@ -195,7 +191,7 @@ public interface ServiceContainer extends ServiceTarget, ServiceRegistry {
          * @return a new service container instance
          */
         public static ServiceContainer create(int coreSize, long keepAliveTime, TimeUnit keepAliveTimeUnit) {
-            return new ServiceContainerImpl(null, coreSize, keepAliveTime, keepAliveTimeUnit, true);
+            return new ServiceContainerImpl(null, calculateCoreSize(coreSize), keepAliveTime, keepAliveTimeUnit, true);
         }
 
         /**
@@ -209,7 +205,7 @@ public interface ServiceContainer extends ServiceTarget, ServiceRegistry {
          * @return a new service container instance
          */
         public static ServiceContainer create(String name, int coreSize, long keepAliveTime, TimeUnit keepAliveTimeUnit) {
-            return new ServiceContainerImpl(name, coreSize, keepAliveTime, keepAliveTimeUnit, true);
+            return new ServiceContainerImpl(name, calculateCoreSize(coreSize), keepAliveTime, keepAliveTimeUnit, true);
         }
 
         /**
@@ -219,9 +215,7 @@ public interface ServiceContainer extends ServiceTarget, ServiceRegistry {
          * @return a new service container instance
          */
         public static ServiceContainer create(boolean autoShutdown) {
-            int cpuCount = Runtime.getRuntime().availableProcessors();
-            int coreSize = Math.min(Math.max(cpuCount << 1, 2), MAX_THREADS_COUNT);
-            return new ServiceContainerImpl(null, coreSize, 30L, TimeUnit.SECONDS, autoShutdown);
+            return new ServiceContainerImpl(null, calculateCoreSize(), 30L, TimeUnit.SECONDS, autoShutdown);
         }
 
         /**
@@ -232,9 +226,7 @@ public interface ServiceContainer extends ServiceTarget, ServiceRegistry {
          * @return a new service container instance
          */
         public static ServiceContainer create(String name, boolean autoShutdown) {
-            int cpuCount = Runtime.getRuntime().availableProcessors();
-            int coreSize = Math.min(Math.max(cpuCount << 1, 2), MAX_THREADS_COUNT);
-            return new ServiceContainerImpl(name, coreSize, 30L, TimeUnit.SECONDS, autoShutdown);
+            return new ServiceContainerImpl(name, calculateCoreSize(), 30L, TimeUnit.SECONDS, autoShutdown);
         }
 
         /**
@@ -248,7 +240,7 @@ public interface ServiceContainer extends ServiceTarget, ServiceRegistry {
          * @return a new service container instance
          */
         public static ServiceContainer create(int coreSize, long keepAliveTime, TimeUnit keepAliveTimeUnit, boolean autoShutdown) {
-            return new ServiceContainerImpl(null, coreSize, keepAliveTime, keepAliveTimeUnit, autoShutdown);
+            return new ServiceContainerImpl(null, calculateCoreSize(coreSize), keepAliveTime, keepAliveTimeUnit, autoShutdown);
         }
 
         /**
@@ -263,7 +255,16 @@ public interface ServiceContainer extends ServiceTarget, ServiceRegistry {
          * @return a new service container instance
          */
         public static ServiceContainer create(String name, int coreSize, long keepAliveTime, TimeUnit keepAliveTimeUnit, boolean autoShutdown) {
-            return new ServiceContainerImpl(name, coreSize, keepAliveTime, keepAliveTimeUnit, autoShutdown);
+            return new ServiceContainerImpl(name, calculateCoreSize(coreSize), keepAliveTime, keepAliveTimeUnit, autoShutdown);
+        }
+
+        private static int calculateCoreSize() {
+            int cpuCount = Runtime.getRuntime().availableProcessors();
+            return calculateCoreSize(Math.max(cpuCount << 1, 2));
+        }
+
+        private static int calculateCoreSize(int coreSize) {
+            return Math.min(coreSize, MAX_THREADS_COUNT);
         }
     }
 


### PR DESCRIPTION
This PR is related to [MSC-144](https://issues.jboss.org/browse/MSC-144).

Wildfly 8.1.0.Final running on Solaris with many cores, caused a large amount of MSC threads to be started (> 32) Investigation led to the use of `jboss.msc.max.container.threads` which at first glance, sounds like the solution. However, setting this property had no effect.

The reason being that Wildfly does not invoke the factory methods with the fix (https://github.com/jboss-msc/jboss-msc/commit/b071e3ccce42784bece4fe27db1da163524d4916). In the absence of the `org.jboss.server.bootstrap.maxThreads` property, it too does a `cores * 2` calculation ([here](https://github.com/wildfly/wildfly/blob/8.1.0.Final/server/src/main/java/org/jboss/as/server/ServerEnvironment.java#L932) used [here](https://github.com/wildfly/wildfly/blob/8.1.0.Final/server/src/main/java/org/jboss/as/server/BootstrapImpl.java#L55)) and invokes [this](https://github.com/wildfly/wildfly/blob/8.1.0.Final/server/src/main/java/org/jboss/as/server/BootstrapImpl.java#L197) factory method, which does not apply the `jboss.msc.max.container.threads` property. The result being that the `jboss.msc.max.container.threads` property has no affect, or at least is not what you would expect.

[This forum thread](https://developer.jboss.org/thread/243505) highlights the confusion caused by the current implementation.

This PR attempts to make the usage of `jboss.msc.max.container.threads` consistent, as it enforces that `MAX_THREADS_COUNT` is always considered and enforced by all factory methods. Regardless of where the core calculation comes from.

References:
- https://issues.jboss.org/browse/MSC-144
- https://twitter.com/aminize/status/446211421538222081
- https://developer.jboss.org/thread/243505
