### PR TITLE
[MSC-245] Fixing ServiceContainerImpl.registry memory leak

### DIFF
--- a/src/main/java/org/jboss/msc/service/ServiceContainerImpl.java
+++ b/src/main/java/org/jboss/msc/service/ServiceContainerImpl.java
@@ -72,7 +72,6 @@ import org.jboss.modules.ref.WeakReference;
 import org.jboss.msc.Version;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.ServiceController.Mode;
-import org.jboss.msc.service.ServiceController.Substate;
 import org.jboss.msc.service.management.ServiceContainerMXBean;
 import org.jboss.msc.service.management.ServiceStatus;
 import org.jboss.msc.value.InjectedValue;
@@ -635,14 +634,14 @@ final class ServiceContainerImpl extends ServiceTargetImpl implements ServiceCon
         if (registration == null) {
             registration = new ServiceRegistrationImpl(name);
             ServiceRegistrationImpl existing = registry.putIfAbsent(name, registration);
-            if(existing != null) {
-                return existing;
-            } else {
-                return registration;
-            }
+            return existing != null ? existing : registration;
         } else {
             return registration;
         }
+    }
+
+    void removeRegistration(final ServiceRegistrationImpl registration) {
+        registry.remove(registration.getName(), registration);
     }
 
     @Override

--- a/src/main/java/org/jboss/msc/service/ServiceControllerImpl.java
+++ b/src/main/java/org/jboss/msc/service/ServiceControllerImpl.java
@@ -242,10 +242,9 @@ final class ServiceControllerImpl<S> implements ServiceController<S>, Dependent 
             synchronized (lock) {
                 lock.acquireWrite();
                 try {
-                    registration.setInstance(this);
+                    registration.set(this, injector);
                     if (injector != null) {
                         injector.setInstance(this);
-                        registration.setInjector(injector);
                     }
                 } finally {
                     lock.releaseWrite();
@@ -1882,6 +1881,7 @@ final class ServiceControllerImpl<S> implements ServiceController<S>, Dependent 
             ServiceRegistrationImpl registration;
             WritableValueImpl injector;
             Lockable lock;
+            boolean removeRegistration;
             for (Entry<ServiceRegistrationImpl, WritableValueImpl> provided : provides.entrySet()) {
                 registration = provided.getKey();
                 injector = provided.getValue();
@@ -1889,10 +1889,12 @@ final class ServiceControllerImpl<S> implements ServiceController<S>, Dependent 
                 synchronized (lock) {
                     lock.acquireWrite();
                     try {
-                        registration.clearInstance(ServiceControllerImpl.this);
                         if (injector != null) {
                             injector.setInstance(null);
-                            registration.clearInjector(injector);
+                        }
+                        removeRegistration = registration.clear(ServiceControllerImpl.this);
+                        if (removeRegistration) {
+                            container.removeRegistration(registration);
                         }
                     } finally {
                         lock.releaseWrite();


### PR DESCRIPTION
https://issues.jboss.org/browse/MSC-245

The fix is the following:

1) When CONTROLLER is scheduled for removal it inspects all
   REGISTRATIONs it is associated with if they can be GC-ed.
2) For every removable REGISTRATION its 'removed' flag is set to true
   (REGISTRATION is removable iff
    - it was associated with current CONTROLLER and
    - it has no DEPENDENTs)
3) Finally every removable REGISTRATION is removed from CONTAINER.registry map.
4) If there is another concurrent thread trying to access REGISTRATION
   scheduled for removal then ConcurrentModificationException is thrown.
   This exception allows installation code to retry the installation process.