### PR TITLE
[MSC-252] Removing double word of service in the thrown exception ServiceNotFoundException

### DIFF
--- a/src/main/java/org/jboss/msc/service/ServiceContainerImpl.java
+++ b/src/main/java/org/jboss/msc/service/ServiceContainerImpl.java
@@ -660,7 +660,7 @@ final class ServiceContainerImpl extends ServiceTargetImpl implements ServiceCon
     public ServiceController<?> getRequiredService(final ServiceName serviceName) throws ServiceNotFoundException {
         final ServiceController<?> controller = getService(serviceName);
         if (controller == null) {
-            throw new ServiceNotFoundException("Service " + serviceName + " not found");
+            throw new ServiceNotFoundException(serviceName + " not found");
         }
         return controller;
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/MSC-252
cloned from https://issues.jboss.org/browse/WFCORE-4515