### PR TITLE
MSC-339 ServiceController.dumpServices() throws NPE if service has no identifier

### DIFF
--- a/src/main/java/org/jboss/msc/service/ServiceControllerImpl.java
+++ b/src/main/java/org/jboss/msc/service/ServiceControllerImpl.java
@@ -1203,7 +1203,7 @@ final class ServiceControllerImpl<S> implements ServiceController<S>, Dependent 
     ServiceStatus getStatus() {
         synchronized (this) {
             final String parentName = parent == null ? null : parent.getName().getCanonicalName();
-            final String name = getName().getCanonicalName();
+            final String name = (this.serviceId != null) ? this.serviceId.getCanonicalName() : null;
             final ServiceName[] aliasNames = getAliases();
             final int aliasLength = aliasNames.length;
             final String[] aliases;

--- a/src/main/java/org/jboss/msc/service/management/ServiceStatus.java
+++ b/src/main/java/org/jboss/msc/service/management/ServiceStatus.java
@@ -63,9 +63,6 @@ public class ServiceStatus implements Serializable {
      */
     @ConstructorProperties({"parentName", "serviceName", "aliases", "serviceClassName", "modeName", "stateName", "substateName", "dependencies", "dependencyFailed", "exception", "dependencyUnavailable"})
     public ServiceStatus(final String parentName, final String serviceName, final String[] aliases, final String serviceClassName, final String modeName, final String stateName, final String substateName, final String[] dependencies, final boolean dependencyFailed, final String exception, final boolean dependencyUnavailable) {
-        if (serviceName == null) {
-            throw new IllegalArgumentException("serviceName is null");
-        }
         if (aliases == null) {
             throw new IllegalArgumentException("aliases is null");
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/MSC-339

Port of https://github.com/jboss-msc/jboss-msc/pull/110 from 1.5 branch.