### PR TITLE
[MSC-345] ServiceBuilder: populate serviceId from provided dependencies

### DIFF
--- a/src/main/java/org/jboss/msc/service/ServiceBuilderImpl.java
+++ b/src/main/java/org/jboss/msc/service/ServiceBuilderImpl.java
@@ -49,7 +49,7 @@ import java.util.function.Supplier;
  */
 final class ServiceBuilderImpl<T> implements ServiceBuilder<T> {
 
-    final ServiceName serviceId;
+    ServiceName serviceId;
     final ServiceControllerImpl<?> parent;
     private final ServiceTargetImpl serviceTarget;
     private final Thread thread = currentThread();
@@ -123,10 +123,20 @@ final class ServiceBuilderImpl<T> implements ServiceBuilder<T> {
         }
         // implementation
         final WritableValueImpl retVal = new WritableValueImpl();
+        boolean isAssigned = false;
         for (final ServiceName dependency : dependencies) {
             addProvidesInternal(dependency, retVal);
+            isAssigned = assignServiceIdIfNull(isAssigned, dependency);
         }
         return (Consumer<V>)retVal;
+    }
+
+    protected boolean assignServiceIdIfNull(boolean isAssigned, final ServiceName dependency) {
+      if (serviceId == null && !isAssigned) {
+          serviceId = dependency;
+          isAssigned = true;
+      }
+      return isAssigned;
     }
 
     @Override

--- a/src/test/java/org/jboss/msc/MultiValueServicesTestCase.java
+++ b/src/test/java/org/jboss/msc/MultiValueServicesTestCase.java
@@ -57,7 +57,8 @@ public class MultiValueServicesTestCase extends AbstractServiceTest {
     @Test
     public void usingJustNewAPI() throws Exception {
         StabilityMonitor monitor = new StabilityMonitor();
-        ServiceBuilder<?> sb1 = serviceContainer.addService(HTTP_CONFIG);
+        ServiceBuilder<?> sb1 = serviceContainer.addService();
+        sb1.provides(HTTP_CONFIG);
         Consumer<String> hostInjector = sb1.provides(HTTP_HOST);
         Consumer<Integer> portInjector = sb1.provides(HTTP_PORT);
         sb1.setInstance(new HttpConfigService(hostInjector, portInjector));
@@ -66,7 +67,8 @@ public class MultiValueServicesTestCase extends AbstractServiceTest {
         assertNotNull(configController);
         assertEquals(configController.getName(), HTTP_CONFIG);
 
-        ServiceBuilder<?> sb2 = serviceContainer.addService(HTTP_SERVER);
+        ServiceBuilder<?> sb2 = serviceContainer.addService();
+        sb2.provides(HTTP_SERVER);
         Supplier<String> hostValue = sb2.requires(HTTP_HOST);
         Supplier<Integer> portValue = sb2.requires(HTTP_PORT);
         HttpServer server = new HttpServer(hostValue, portValue);


### PR DESCRIPTION
Reported: https://issues.redhat.com/browse/MSC-345

**Issue:**
When the new API is used 
```
        ServiceBuilder<?> sb1 = serviceContainer.addService();
        sb1.provides(HTTP_CONFIG);
        ...
        ServiceController configController = sb1.install();
// then
        configController.getServiceContainer().dumpServices(); // -> prints Service "null" (class org.jboss.msc.MultiValueServicesTestCase$HttpConfigService) mode ACTIVE state DOWN (START_REQUESTED)
        assertEquals(configController.getName(), HTTP_CONFIG); // throws java.lang.AssertionError: expected:<null> but was:<service http.config>
```

**Root cause:**
The `org.jboss.msc.service.ServiceBuilderImpl.serviceId` is not initialized when the new API is used. This PR suggests population of `serviceId` to the provided value name if not initialized yet.

**Alternative:** 
Add API endpoint to provide a service name similar to the deprecated `org.jboss.msc.service.ServiceTarget.addService(ServiceName)`.

**Context:**
We attempted to remove all of the JBoss MSC deprecated API in our WildFly subsytem, however the `null` service name (`serviceId`) prevents us of do it so. (In addition, we found a lot of usage of the deprecated API in the WildFly libraries as well, pointing to low adoption of the non-deprecated API.)

**Question:**
When the new API was introduced (https://github.com/jboss-msc/jboss-msc/commit/a6dab15435862b53eca77a32d266b4afb4ba2a97) encapsulating the service, was it intended to not use and initialize the `serviceId` anymore? 