### PR TITLE
[MSC-334] Deprecate ServiceTarget.addService(ServiceName) in favor of ServiceTarget.addService() method

### DIFF
--- a/src/main/java/org/jboss/msc/service/ServiceTarget.java
+++ b/src/main/java/org/jboss/msc/service/ServiceTarget.java
@@ -78,6 +78,7 @@ public interface ServiceTarget {
      * @deprecated Use {@link #addService()} instead.
      * This method will be removed in a future release.
      */
+    @Deprecated
     ServiceBuilder<?> addService(ServiceName name);
 
     /**


### PR DESCRIPTION
https://issues.redhat.com/browse/MSC-334

Downstream PR: https://github.com/jboss-msc/jboss-msc/pull/149