### PR TITLE
[MSC-350] Reworked JBoss MSC Container MBean methods to match the new JBoss MSC values API

### DIFF
--- a/src/main/java/org/jboss/msc/service/Functions.java
+++ b/src/main/java/org/jboss/msc/service/Functions.java
@@ -1,0 +1,217 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2025, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.msc.service;
+
+import org.jboss.msc.service.management.ServiceStatus;
+
+import java.util.function.Function;
+
+/**
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
+ */
+final class Functions {
+
+    private Functions() {
+        // forbidden instantiation
+    }
+
+    static final class ServiceIdentityFunction implements Function<ServiceStatus, ServiceStatus> {
+        static final Function<ServiceStatus, ServiceStatus> INSTANCE = new ServiceIdentityFunction();
+
+        @Override
+        public ServiceStatus apply(final ServiceStatus serviceStatus) {
+            return serviceStatus;
+        }
+    }
+
+    static final class ServiceIdIdentityFunction implements Function<ServiceStatus, String> {
+        static final Function<ServiceStatus, String> INSTANCE = new ServiceIdIdentityFunction();
+
+        @Override
+        public String apply(final ServiceStatus serviceStatus) {
+            return serviceStatus.getId();
+        }
+    }
+
+    static final class ServiceRequiringValueFunction implements Function<ServiceStatus, ServiceStatus> {
+        private final String expectedValue;
+
+        ServiceRequiringValueFunction(final String expectedValue) {
+            this.expectedValue = expectedValue;
+        }
+
+        @Override
+        public ServiceStatus apply(final ServiceStatus serviceStatus) {
+            for (String requiredValue : serviceStatus.getRequiredValues()) {
+                if (requiredValue.equals(expectedValue)) return serviceStatus;
+            }
+            return null;
+        }
+    }
+
+    static final class ServiceIdRequiringValueFunction implements Function<ServiceStatus, String> {
+        private final String expectedValue;
+
+        ServiceIdRequiringValueFunction(final String expectedValue) {
+            this.expectedValue = expectedValue;
+        }
+
+        @Override
+        public String apply(final ServiceStatus serviceStatus) {
+            for (String requiredValue : serviceStatus.getRequiredValues()) {
+                if (requiredValue.equals(expectedValue)) return serviceStatus.getId();
+            }
+            return null;
+        }
+    }
+
+    static final class ServiceProvidingValueFunction implements Function<ServiceStatus, ServiceStatus> {
+        private final String expectedValue;
+
+        ServiceProvidingValueFunction(final String expectedValue) {
+            this.expectedValue = expectedValue;
+        }
+
+        @Override
+        public ServiceStatus apply(final ServiceStatus serviceStatus) {
+            for (String providedValue : serviceStatus.getProvidedValues()) {
+                if (providedValue.equals(expectedValue)) return serviceStatus;
+            }
+            return null;
+        }
+    }
+
+    static final class ServiceIdProvidingValueFunction implements Function<ServiceStatus, String> {
+        private final String expectedValue;
+
+        ServiceIdProvidingValueFunction(final String expectedValue) {
+            this.expectedValue = expectedValue;
+        }
+
+        @Override
+        public String apply(final ServiceStatus serviceStatus) {
+            for (String providedValue : serviceStatus.getProvidedValues()) {
+                if (providedValue.equals(expectedValue)) return serviceStatus.getId();
+            }
+            return null;
+        }
+    }
+
+    static final class ServiceMissingValueFunction implements Function<ServiceStatus, ServiceStatus> {
+        private final String expectedValue;
+
+        ServiceMissingValueFunction(final String expectedValue) {
+            this.expectedValue = expectedValue;
+        }
+
+        @Override
+        public ServiceStatus apply(final ServiceStatus serviceStatus) {
+            for (String missingValue : serviceStatus.getMissingValues()) {
+                if (missingValue.equals(expectedValue)) return serviceStatus;
+            }
+            return null;
+        }
+    }
+
+    static final class ServiceIdMissingValueFunction implements Function<ServiceStatus, String> {
+        private final String expectedValue;
+
+        ServiceIdMissingValueFunction(final String expectedValue) {
+            this.expectedValue = expectedValue;
+        }
+
+        @Override
+        public String apply(final ServiceStatus serviceStatus) {
+            for (String missingValue : serviceStatus.getMissingValues()) {
+                if (missingValue.equals(expectedValue)) return serviceStatus.getId();
+            }
+            return null;
+        }
+    }
+
+    static final class ServiceIdFunction implements Function<ServiceStatus, ServiceStatus> {
+        private final String expectedValue;
+
+        ServiceIdFunction(final String expectedValue) {
+            this.expectedValue = expectedValue;
+        }
+
+        @Override
+        public ServiceStatus apply(final ServiceStatus serviceStatus) {
+            return serviceStatus.getId().equals(expectedValue) ? serviceStatus : null;
+        }
+    }
+
+    static final class ServiceStateFunction implements Function<ServiceStatus, ServiceStatus> {
+        private final String expectedValue;
+
+        ServiceStateFunction(final String expectedValue) {
+            this.expectedValue = expectedValue;
+        }
+
+        @Override
+        public ServiceStatus apply(final ServiceStatus serviceStatus) {
+            return serviceStatus.getState().equals(expectedValue) ? serviceStatus : null;
+        }
+    }
+
+    static final class ServiceIdStateFunction implements Function<ServiceStatus, String> {
+        private final String expectedValue;
+
+        ServiceIdStateFunction(final String expectedValue) {
+            this.expectedValue = expectedValue;
+        }
+
+        @Override
+        public String apply(final ServiceStatus serviceStatus) {
+            return serviceStatus.getState().equals(expectedValue) ? serviceStatus.getId() : null;
+        }
+    }
+
+    static final class ServiceModeFunction implements Function<ServiceStatus, ServiceStatus> {
+        private final String expectedValue;
+
+        ServiceModeFunction(final String expectedValue) {
+            this.expectedValue = expectedValue;
+        }
+
+        @Override
+        public ServiceStatus apply(final ServiceStatus serviceStatus) {
+            return serviceStatus.getMode().equals(expectedValue) ? serviceStatus : null;
+        }
+    }
+
+    static final class ServiceIdModeFunction implements Function<ServiceStatus, String> {
+        private final String expectedValue;
+
+        ServiceIdModeFunction(final String expectedValue) {
+            this.expectedValue = expectedValue;
+        }
+
+        @Override
+        public String apply(final ServiceStatus serviceStatus) {
+            return serviceStatus.getMode().equals(expectedValue) ? serviceStatus.getId() : null;
+        }
+    }
+
+}

--- a/src/main/java/org/jboss/msc/service/ServiceContainerMXBeanImpl.java
+++ b/src/main/java/org/jboss/msc/service/ServiceContainerMXBeanImpl.java
@@ -1,0 +1,394 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2025, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.msc.service;
+
+import org.jboss.msc.service.management.ServiceContainerMXBean;
+import org.jboss.msc.service.management.ServiceStatus;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+
+/**
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
+ */
+final class ServiceContainerMXBeanImpl implements ServiceContainerMXBean {
+
+    private static final String LS = System.lineSeparator();
+    private static final String DOUBLE_LS = LS.repeat(2);
+
+    private final ConcurrentMap<ServiceName, ServiceRegistrationImpl> registry;
+    private final String containerName;
+
+    ServiceContainerMXBeanImpl(final String containerName, final ConcurrentMap<ServiceName, ServiceRegistrationImpl> registry) {
+        this.containerName = containerName;
+        this.registry = registry;
+    }
+
+    @Override
+    public Set<String> queryValues() {
+        final Set<ServiceName> values = registry.keySet();
+        final Set<String> retVal = new TreeSet<>();
+        for (ServiceName value : values) {
+            retVal.add(value.getCanonicalName());
+        }
+        return retVal;
+    }
+
+    @Override
+    public void dumpValues() {
+        dumpValues(System.out);
+    }
+
+    @Override
+    public String dumpValuesToString() {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final PrintStream out = new PrintStream(baos, false, UTF_8);
+        dumpValues(out);
+        return baos.toString(UTF_8);
+    }
+
+    @Override
+    public Set<String> queryServiceIds() {
+        return queryServiceIds(Functions.ServiceIdIdentityFunction.INSTANCE);
+    }
+
+    @Override
+    public void dumpServiceIds() {
+        dumpServiceIds(null, Functions.ServiceIdIdentityFunction.INSTANCE, null, System.out);
+    }
+
+    @Override
+    public String dumpServiceIdsToString() {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final PrintStream out = new PrintStream(baos, false, UTF_8);
+        dumpServiceIds(null, Functions.ServiceIdIdentityFunction.INSTANCE, null, out);
+        return baos.toString(UTF_8);
+    }
+
+    @Override
+    public Set<ServiceStatus> queryServices() {
+        return queryServices(Functions.ServiceIdentityFunction.INSTANCE);
+    }
+
+    @Override
+    public void dumpServices() {
+        dumpServices(null, Functions.ServiceIdentityFunction.INSTANCE, null, System.out);
+    }
+
+    @Override
+    public String dumpServicesToString() {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final PrintStream out = new PrintStream(baos, false, UTF_8);
+        dumpServices(null, Functions.ServiceIdentityFunction.INSTANCE, null, out);
+        return baos.toString(UTF_8);
+    }
+
+    @Override
+    public Set<ServiceStatus> queryServicesRequiringValue(final String value) {
+        return queryServices(new Functions.ServiceRequiringValueFunction(value));
+    }
+
+    @Override
+    public void dumpServicesRequiringValue(final String value) {
+        dumpServices("requiring value", new Functions.ServiceRequiringValueFunction(value), value, System.out);
+    }
+
+    @Override
+    public String dumpServicesRequiringValueToString(final String value) {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final PrintStream out = new PrintStream(baos, false, UTF_8);
+        dumpServices("requiring value", new Functions.ServiceRequiringValueFunction(value), value, out);
+        return baos.toString(UTF_8);
+    }
+
+    @Override
+    public Set<String> queryServiceIdsRequiringValue(final String value) {
+        return queryServiceIds(new Functions.ServiceIdRequiringValueFunction(value));
+    }
+
+    @Override
+    public void dumpServiceIdsRequiringValue(final String value) {
+        dumpServiceIds("requiring value", new Functions.ServiceIdRequiringValueFunction(value), value, System.out);
+    }
+
+    @Override
+    public String dumpServiceIdsRequiringValueToString(final String value) {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final PrintStream out = new PrintStream(baos, false, UTF_8);
+        dumpServiceIds("requiring value", new Functions.ServiceIdRequiringValueFunction(value), value, out);
+        return baos.toString(UTF_8);
+    }
+
+    @Override
+    public ServiceStatus queryServiceProvidingValue(final String value) {
+        final Iterator<ServiceStatus> i = queryServices(new Functions.ServiceProvidingValueFunction(value)).iterator();
+        return i.hasNext() ? i.next() : null;
+    }
+
+    @Override
+    public void dumpServiceProvidingValue(final String value) {
+        dumpServices("providing value", new Functions.ServiceProvidingValueFunction(value), value, System.out);
+    }
+
+    @Override
+    public String dumpServiceProvidingValueToString(final String value) {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final PrintStream out = new PrintStream(baos, false, UTF_8);
+        dumpServices("providing value", new Functions.ServiceProvidingValueFunction(value), value, out);
+        return baos.toString(UTF_8);
+    }
+
+    @Override
+    public String queryServiceIdProvidingValue(final String value) {
+        final Iterator<String> i = queryServiceIds(new Functions.ServiceIdProvidingValueFunction(value)).iterator();
+        return i.hasNext() ? i.next() : null;
+    }
+
+    @Override
+    public void dumpServiceIdProvidingValue(final String value) {
+        dumpServiceIds("providing value", new Functions.ServiceIdProvidingValueFunction(value), value, System.out);
+    }
+
+    @Override
+    public String dumpServiceIdProvidingValueToString(final String value) {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final PrintStream out = new PrintStream(baos, false, UTF_8);
+        dumpServiceIds("providing value", new Functions.ServiceIdProvidingValueFunction(value), value, out);
+        return baos.toString(UTF_8);
+    }
+
+    @Override
+    public Set<ServiceStatus> queryServicesMissingValue(final String value) {
+        return queryServices(new Functions.ServiceMissingValueFunction(value));
+    }
+
+    @Override
+    public void dumpServicesMissingValue(final String value) {
+        dumpServices("missing value", new Functions.ServiceMissingValueFunction(value), value, System.out);
+    }
+
+    @Override
+    public String dumpServicesMissingValueToString(final String value) {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final PrintStream out = new PrintStream(baos, false, UTF_8);
+        dumpServices("missing value", new Functions.ServiceMissingValueFunction(value), value, out);
+        return baos.toString(UTF_8);
+    }
+
+    @Override
+    public Set<String> queryServiceIdsMissingValue(final String value) {
+        return queryServiceIds(new Functions.ServiceIdMissingValueFunction(value));
+    }
+
+    @Override
+    public void dumpServiceIdsMissingValue(final String value) {
+        dumpServiceIds("missing value", new Functions.ServiceIdMissingValueFunction(value), value, System.out);
+    }
+
+    @Override
+    public String dumpServiceIdsMissingValueToString(final String value) {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final PrintStream out = new PrintStream(baos, false, UTF_8);
+        dumpServiceIds("missing value", new Functions.ServiceIdMissingValueFunction(value), value, out);
+        return baos.toString(UTF_8);
+    }
+
+    @Override
+    public ServiceStatus queryServiceById(final String id) {
+        final Iterator<ServiceStatus> i = queryServices(new Functions.ServiceIdFunction(id)).iterator();
+        return i.hasNext() ? i.next() : null;
+    }
+
+    @Override
+    public void dumpServiceById(final String id) {
+        dumpServices("of id", new Functions.ServiceIdFunction(id), id, System.out);
+    }
+
+    @Override
+    public String dumpServiceByIdToString(final String id) {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final PrintStream out = new PrintStream(baos, false, UTF_8);
+        dumpServices("of id", new Functions.ServiceIdFunction(id), id, out);
+        return baos.toString(UTF_8);
+    }
+
+    @Override
+    public Set<ServiceStatus> queryServicesByState(final String state) {
+        return queryServices(new Functions.ServiceStateFunction(state));
+    }
+
+    @Override
+    public void dumpServicesByState(final String state) {
+        dumpServices("in state", new Functions.ServiceStateFunction(state), state, System.out);
+    }
+
+    @Override
+    public String dumpServicesByStateToString(final String state) {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final PrintStream out = new PrintStream(baos, false, UTF_8);
+        dumpServices("in state", new Functions.ServiceStateFunction(state), state, out);
+        return baos.toString(UTF_8);
+    }
+
+    @Override
+    public Set<String> queryServiceIdsByState(final String state) {
+        return queryServiceIds(new Functions.ServiceIdStateFunction(state));
+    }
+
+    @Override
+    public void dumpServiceIdsByState(final String state) {
+        dumpServiceIds("in state", new Functions.ServiceIdStateFunction(state), state, System.out);
+    }
+
+    @Override
+    public String dumpServiceIdsByStateToString(final String state) {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final PrintStream out = new PrintStream(baos, false, UTF_8);
+        dumpServiceIds("in state", new Functions.ServiceIdStateFunction(state), state, out);
+        return baos.toString(UTF_8);
+    }
+
+    @Override
+    public Set<ServiceStatus> queryServicesByMode(final String mode) {
+        return queryServices(new Functions.ServiceModeFunction(mode));
+    }
+
+    @Override
+    public void dumpServicesByMode(final String mode) {
+        dumpServices("in mode", new Functions.ServiceModeFunction(mode), mode, System.out);
+    }
+
+    @Override
+    public String dumpServicesByModeToString(final String mode) {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final PrintStream out = new PrintStream(baos, false, UTF_8);
+        dumpServices("in mode", new Functions.ServiceModeFunction(mode), mode, out);
+        return baos.toString(UTF_8);
+    }
+
+    @Override
+    public Set<String> queryServiceIdsByMode(final String mode) {
+        return queryServiceIds(new Functions.ServiceIdModeFunction(mode));
+    }
+
+    @Override
+    public void dumpServiceIdsByMode(final String mode) {
+        dumpServiceIds("in mode", new Functions.ServiceIdModeFunction(mode), mode, System.out);
+    }
+
+    @Override
+    public String dumpServiceIdsByModeToString(final String mode) {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final PrintStream out = new PrintStream(baos, false, UTF_8);
+        dumpServiceIds("in mode", new Functions.ServiceIdModeFunction(mode), mode, out);
+        return baos.toString(UTF_8);
+    }
+
+    void dumpServices(final String conditionDescription, final Function<ServiceStatus, ServiceStatus> function, final String value, final PrintStream out) {
+        final Collection<ServiceStatus> services = queryServices(function);
+        synchronized (out) {
+            if (conditionDescription != null) {
+                out.printf("Number of services in container \"%s\" " + conditionDescription + " \"%s\" is: %d", containerName, value, services.size());
+                out.print(DOUBLE_LS);
+            } else {
+                out.printf("Number of services in container \"%s\" is: %d", containerName, services.size());
+                out.print(DOUBLE_LS);
+            }
+            for (ServiceStatus service : services) {
+                out.print(service);
+                out.print(LS);
+            }
+            out.print(LS);
+            out.flush();
+        }
+    }
+
+    private void dumpValues(final PrintStream out) {
+        final Collection<String> values = queryValues();
+        synchronized (out) {
+            out.printf("Number of values in container \"%s\" is: %d", containerName, values.size());
+            out.print(DOUBLE_LS);
+            for (String value : values) {
+                out.print(value);
+                out.print(LS);
+            }
+            out.print(LS);
+            out.flush();
+        }
+    }
+
+    private void dumpServiceIds(final String conditionDescription, final Function<ServiceStatus, String> function, final String value, final PrintStream out) {
+        final Collection<String> serviceIds = queryServiceIds(function);
+        synchronized (out) {
+            if (conditionDescription != null) {
+                out.printf("Number of service identifiers in container \"%s\" " + conditionDescription + " \"%s\" is: %d", containerName, value, serviceIds.size());
+                out.print(DOUBLE_LS);
+            } else {
+                out.printf("Number of service identifiers in container \"%s\" is: %d", containerName, serviceIds.size());
+                out.print(DOUBLE_LS);
+            }
+            for (String serviceId : serviceIds) {
+                out.print(serviceId);
+                out.print(LS);
+            }
+            out.print(LS);
+            out.flush();
+        }
+    }
+
+    private Set<ServiceStatus> queryServices(final Function<ServiceStatus, ServiceStatus> function) {
+        final Collection<ServiceRegistrationImpl> values = registry.values();
+        final Set<ServiceStatus> retVal = new TreeSet<>();
+        ServiceStatus service;
+        ServiceControllerImpl<?> controller;
+        for (ServiceRegistrationImpl value : values) {
+            controller = value.getDependencyController();
+            if (controller == null) continue;
+            service = function.apply(controller.getStatus());
+            if (service != null) retVal.add(service);
+        }
+        return retVal;
+    }
+
+    private Set<String> queryServiceIds(final Function<ServiceStatus, String> function) {
+        final Collection<ServiceRegistrationImpl> values = registry.values();
+        final Set<String> retVal = new TreeSet<>();
+        String serviceId;
+        ServiceControllerImpl<?> controller;
+        for (ServiceRegistrationImpl value : values) {
+            controller = value.getDependencyController();
+            if (controller == null) continue;
+            serviceId = function.apply(controller.getStatus());
+            if (serviceId != null) retVal.add(serviceId);
+        }
+        return retVal;
+    }
+}

--- a/src/main/java/org/jboss/msc/service/management/ServiceContainerMXBean.java
+++ b/src/main/java/org/jboss/msc/service/management/ServiceContainerMXBean.java
@@ -22,86 +22,352 @@
 
 package org.jboss.msc.service.management;
 
-import java.util.List;
+import java.util.Set;
 
 /**
  * The service container management bean interface.
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
 public interface ServiceContainerMXBean {
 
     /**
-     * Get the status of one service.
+     * Gets all registered values.
      *
-     * @param name the service name
-     * @return the status
+     * @return all registered values
      */
-    ServiceStatus getServiceStatus(String name);
+    Set<String> queryValues();
 
     /**
-     * Get a list of service names in this container.
-     *
-     * @return the list of names
+     * Dumps all registered values to system console.
+     * The output has no particular standard format and may change over time.
      */
-    List<String> queryServiceNames();
+    void dumpValues();
 
     /**
-     * Get a list of service statuses in this container.
+     * Dumps all registered values to string.
+     * The output has no particular standard format and may change over time.
      *
-     * @return the list of statuses
+     * @return all registered values as string
      */
-    List<ServiceStatus> queryServiceStatuses();
+    String dumpValuesToString();
 
     /**
-     * Change the mode of a service.
+     * Gets all registered service ids.
      *
-     * @param name the service name
-     * @param mode the new mode
+     * @return all registered service ids
      */
-    void setServiceMode(String name, String mode);
+    Set<String> queryServiceIds();
 
     /**
-     * Dump the container state to the console.
+     * Dumps all registered service ids to system console.
+     * The output has no particular standard format and may change over time.
+     */
+    void dumpServiceIds();
+
+    /**
+     * Dumps all registered service ids to string.
+     * The output has no particular standard format and may change over time.
+     *
+     * @return all registered service ids as string
+     */
+    String dumpServiceIdsToString();
+
+    /**
+     * Gets the statuses of all registered services.
+     *
+     * @return the statuses of all registered services
+     */
+    Set<ServiceStatus> queryServices();
+
+    /**
+     * Dumps the statuses of all registered services to system console.
+     * The output has no particular standard format and may change over time.
      */
     void dumpServices();
 
     /**
-     * Dump the container state to a big string.  The string has no particular standard format and may
-     * change over time; this method is simply a convenience.
+     * Dumps the statuses of all registered services to string.
+     * The output has no particular standard format and may change over time.
      *
-     * @return the container state, as a string
+     * @return the statuses of all registered services as string
      */
     String dumpServicesToString();
 
     /**
-     * Dump the container state to a string suitable for rendering in GraphViz or compatible tools.
+     * Gets the services that require the given value.
      *
-     * @return the container state graph
+     * @param value the name of the value
+     * @return the services that require the given value
      */
-    String dumpServicesToGraphDescription();
+    Set<ServiceStatus> queryServicesRequiringValue(String value);
 
     /**
-     * Dump all details of a service.
+     * Dumps the services that require the given value to system console.
+     * The output has no particular standard format and may change over time.
      *
-     * @param serviceName the name of the service to examine
-     * @return the details, as a string
+     * @param value the name of the value
      */
-    String dumpServiceDetails(String serviceName);
+    void dumpServicesRequiringValue(String value);
 
     /**
-     * Dump the services, whose status matches the passed <code>status</code> to the console
+     * Dumps the services that require the given value to string.
+     * The output has no particular standard format and may change over time.
      *
-     * @param status The status of the services that we are interested in
+     * @param value the name of the value
+     * @return the services that require the given value as string
      */
-    void dumpServicesByStatus(String status);
+    String dumpServicesRequiringValueToString(String value);
 
     /**
-     * Dump the services, whose status matches the passed <code>status</code>, state to a big string.
-     * The string has no particular standard format and may change over time; this method is simply a convenience.
+     * Gets the service ids that require the given value.
      *
-     * @param status The status of the services that we are interested in
-     * @return Returns the string representation of the services whose status matches the passed <code>status</code>
+     * @param value the name of the value
+     * @return the service ids that require the given value
      */
-    String dumpServicesToStringByStatus(String status);
+    Set<String> queryServiceIdsRequiringValue(String value);
+
+    /**
+     * Dumps the service ids that require the given value to system console.
+     * The output has no particular standard format and may change over time.
+     *
+     * @param value the name of the value
+     */
+    void dumpServiceIdsRequiringValue(String value);
+
+    /**
+     * Dumps the service ids that require the given value to string.
+     * The output has no particular standard format and may change over time.
+     *
+     * @param value the name of the value
+     * @return the service ids that require the given value as string
+     */
+    String dumpServiceIdsRequiringValueToString(String value);
+
+    /**
+     * Gets the service that provides the given value.
+     *
+     * @param value the name of the value
+     * @return the service that provides the given value
+     */
+    ServiceStatus queryServiceProvidingValue(String value);
+
+    /**
+     * Dumps the service that provides the given value to system console.
+     * The output has no particular standard format and may change over time.
+     *
+     * @param value the name of the value
+     */
+    void dumpServiceProvidingValue(String value);
+
+    /**
+     * Dumps the service that provides the given value to string.
+     * The output has no particular standard format and may change over time.
+     *
+     * @param value the name of the value
+     * @return the service that provides the given value as string
+     */
+    String dumpServiceProvidingValueToString(String value);
+
+    /**
+     * Gets the service id that provides the given value.
+     *
+     * @param value the name of the value
+     * @return the service id that provides the given value
+     */
+    String queryServiceIdProvidingValue(String value);
+
+    /**
+     * Dumps the service id that provides the given value to system console.
+     * The output has no particular standard format and may change over time.
+     *
+     * @param value the name of the value
+     */
+    void dumpServiceIdProvidingValue(String value);
+
+    /**
+     * Dumps the service id that provides the given value to string.
+     * The output has no particular standard format and may change over time.
+     *
+     * @param value the name of the value
+     * @return the service id that provides the given value as string
+     */
+    String dumpServiceIdProvidingValueToString(String value);
+
+    /**
+     * Gets the services missing the given value.
+     *
+     * @param value the name of the value
+     * @return the services missing the given value
+     */
+    Set<ServiceStatus> queryServicesMissingValue(String value);
+
+    /**
+     * Dumps the services missing the given value to system console.
+     * The output has no particular standard format and may change over time.
+     *
+     * @param value the name of the value
+     */
+    void dumpServicesMissingValue(String value);
+
+    /**
+     * Dumps the services missing the given value to string.
+     * The output has no particular standard format and may change over time.
+     *
+     * @param value the name of the value
+     * @return the services missing the given value as string
+     */
+    String dumpServicesMissingValueToString(String value);
+
+    /**
+     * Gets the service ids missing the given value.
+     *
+     * @param value the name of the value
+     * @return the service ids missing the given value
+     */
+    Set<String> queryServiceIdsMissingValue(String value);
+
+    /**
+     * Dumps the service ids missing the given value to system console.
+     * The output has no particular standard format and may change over time.
+     *
+     * @param value the name of the value
+     */
+    void dumpServiceIdsMissingValue(String value);
+
+    /**
+     * Dumps the service ids missing the given value to string.
+     * The output has no particular standard format and may change over time.
+     *
+     * @param value the name of the value
+     * @return the service ids missing the given value as string
+     */
+    String dumpServiceIdsMissingValueToString(String value);
+
+    /**
+     * Gets the service with given id.
+     *
+     * @param id the service runtime identification
+     * @return the service with given id
+     */
+    ServiceStatus queryServiceById(String id);
+
+    /**
+     * Dumps the service with given id to system console.
+     * The output has no particular standard format and may change over time.
+     *
+     * @param id the service runtime identification
+     */
+    void dumpServiceById(String id);
+
+    /**
+     * Dumps the service with given id to string.
+     * The output has no particular standard format and may change over time.
+     *
+     * @param id the service runtime identification
+     * @return the service with given id as string
+     */
+    String dumpServiceByIdToString(String id);
+
+    /**
+     * Gets the services in given state.
+     *
+     * @param state the name of the state
+     * @return the services in given state
+     */
+    Set<ServiceStatus> queryServicesByState(String state);
+
+    /**
+     * Dumps the services in given state to system console.
+     * The output has no particular standard format and may change over time.
+     *
+     * @param state the name of the state
+     */
+    void dumpServicesByState(String state);
+
+    /**
+     * Dumps the services in given state to string.
+     * The output has no particular standard format and may change over time.
+     *
+     * @param state the name of the state
+     * @return the services in given state as string
+     */
+    String dumpServicesByStateToString(String state);
+
+    /**
+     * Gets the service ids in given state.
+     *
+     * @param state the name of the state
+     * @return the service ids in given state
+     */
+    Set<String> queryServiceIdsByState(String state);
+
+    /**
+     * Dumps the service ids in given state to system console.
+     * The output has no particular standard format and may change over time.
+     *
+     * @param state the name of the state
+     */
+    void dumpServiceIdsByState(String state);
+
+    /**
+     * Dumps the service ids in given state to string.
+     * The output has no particular standard format and may change over time.
+     *
+     * @param state the name of the state
+     * @return the service ids in given state as string
+     */
+    String dumpServiceIdsByStateToString(String state);
+
+    /**
+     * Gets the services in given mode.
+     *
+     * @param mode the name of the mode
+     * @return the services in given mode
+     */
+    Set<ServiceStatus> queryServicesByMode(String mode);
+
+    /**
+     * Dumps the services in given mode to system console.
+     * The output has no particular standard format and may change over time.
+     *
+     * @param mode the name of the mode
+     */
+    void dumpServicesByMode(String mode);
+
+    /**
+     * Dumps the services in given mode to string.
+     * The output has no particular standard format and may change over time.
+     *
+     * @param mode the name of the mode
+     * @return the services in given mode as string
+     */
+    String dumpServicesByModeToString(String mode);
+
+    /**
+     * Gets the service ids in given mode.
+     *
+     * @param mode the name of the mode
+     * @return the service ids in given mode
+     */
+    Set<String> queryServiceIdsByMode(String mode);
+
+    /**
+     * Dumps the service ids in given mode to system console.
+     * The output has no particular standard format and may change over time.
+     *
+     * @param mode the name of the mode
+     */
+    void dumpServiceIdsByMode(String mode);
+
+    /**
+     * Dumps the service ids in given mode to string.
+     * The output has no particular standard format and may change over time.
+     *
+     * @param mode the name of the mode
+     * @return the service ids in given mode as string
+     */
+    String dumpServiceIdsByModeToString(String mode);
+
 }

--- a/src/test/java/org/jboss/msc/MSC245TestCase.java
+++ b/src/test/java/org/jboss/msc/MSC245TestCase.java
@@ -123,6 +123,6 @@ public class MSC245TestCase {
         properties.put("type", "container");
         properties.put("name", CONTAINER_NAME);
         final ObjectName containerON = new ObjectName("jboss.msc", properties);
-        return ((String[])server.invoke(containerON, "queryServiceNames", null, null)).length;
+        return ((String[])server.invoke(containerON, "queryValues", null, null)).length;
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/MSC-350

The service status console/string output has changes - it is now more human friendly. ServiceContainerMXBean methods have been revisited and the following query methods are available since now on:

```
       Set<String> queryValues()                               // gets all values (required or provided) in the container
Set<ServiceStatus> queryServices()                             // gets all services available in the container
       Set<String> queryServiceIds()                           // gets all service ids available in the container
Set<ServiceStatus> queryServicesRequiringValue(String value)   // gets services requiring given value
       Set<String> queryServiceIdsRequiringValue(String value) // gets service ids requiring given value
     ServiceStatus queryServiceProvidingValue(String value)    // gets service providing given value
            String queryServiceIdProvidingValue(String value)  // gets service id providing given value
Set<ServiceStatus> queryServicesMissingValue(String value)     // gets services missing given value
       Set<String> queryServiceIdsMissingValue(String value)   // gets service ids missing given value
     ServiceStatus queryServiceById(String id)                 // gets service of given id
Set<ServiceStatus> queryServicesByState(String state)          // gets all services in given state
       Set<String> queryServiceIdsByState(String state)        // gets all service ids in given state
Set<ServiceStatus> queryServicesByMode(String mode)            // gets all services in given mode
       Set<String> queryServiceIdsByMode(String mode)          // gets all service ids in given mode

```
Also every XYZ query method above has two more alternatives available:
```
              void dumpXYZ()                                   // dumps XYZ query output to system concole
            String dumpXYZToString()                           // dumps XYZ query output to a string
```